### PR TITLE
Add nodejs demo - with transcribe_file option 

### DIFF
--- a/nodejs-asr/transcribe.js
+++ b/nodejs-asr/transcribe.js
@@ -25,11 +25,11 @@ const transcribeRaw = async (data, token) => {
             throw new Error('Problem transcribing file: ' + msg);
         }
     } catch (err) {
-        if (err.response && err.response.status==401) {
+        if (err?.response.status === 401) {
             throw new Error("Authorization failure. Do you need to set the auth token (variable in transcribe.js)?");  
         }
-        if (err.response && err.response.data && err.response.data.detail) {
-            throw new Error("Error transcribing file: (" + err.response.status + ') ' + err.response.data.detail);
+        if (err?.response?.data?.detail) {
+            throw new Error(`Error transcribing file: (${err.response.status}) ${err.response.data.detail}`, err);
         }
         else {
             console.error(err);

--- a/nodejs-asr/transcribe_file.js
+++ b/nodejs-asr/transcribe_file.js
@@ -1,4 +1,3 @@
-import { Buffer, Blob } from 'buffer';
 import axios from 'axios';
 import FormData from 'form-data';
 import fs from 'fs';
@@ -7,36 +6,29 @@ import { auth_token } from './config.js'
 const transcribeFile = async (filename) => {
 
     const formData = new FormData();
-    formData.enctype = "multipart/form-data";
-    //formData.append('audio_file', data, 'audio_file.mp3')        
     formData.append('audio_file', fs.createReadStream(filename));
-
     const url = 'https://asr.koreromaori.io/transcribe_file'
     const config = {
         headers: {
-            'content-type': 'multipart/form-data',
-            'Authorization': 'Token ' + auth_token
+            'Authorization': 'Token ' + auth_token,
+            ...formData.getHeaders(),
         }
     };
 
     try {
-        var response = await axios.post(url, formData, config);
-        if (response.status==200 && response.data.success)
-        {
-            //console.log(response.data)
+        const response = await axios.post(url, formData, config);
+        if (response.status === 200 && response.data.success) {
             return response.data.transcription;
         }
         else {
-            msg = response.data.log;
-            //console.error(msg)
-            throw new Error('Problem transcribing file: ' + msg);
+            throw new Error(`Problem transcribing file:${response.data.log} ` + msg);
         }
     } catch (err) {
-        if (err.response && err.response.status==401) {
+        if (err?.response?.status === 401) {
             throw new Error("Authorization failure. Do you need to set the auth token (variable in transcribe.js)?");  
         }
-        if (err.response && err.response.data && err.response.data.detail) {
-            throw new Error("Error transcribing file: (" + err.response.status + ') ' + err.response.data.detail);
+        if (err?.response?.data?.detail) {
+            throw new Error(`Error transcribing file: (${err.response.status}) ${err.response.data.detail}`, err);
         }
         else {
             console.error(err);
@@ -45,31 +37,6 @@ const transcribeFile = async (filename) => {
           
     }
 }
-
-// const readDataFromUrl = async (url, mimetype) => {
-//     try {
-//         var response = await axios.get(url,{
-//             responseType: 'arraybuffer',
-//             headers: {
-//                 'Content-Type': 'application/json',
-//                 'Accept': mimetype,
-//             }
-//         });
-//         if (response.status==200)
-//         {
-//             return response.data;
-//         }
-//     } catch (err) {
-//         throw new Error('Error reading file');
-//     }
-// }
-
-// using the test file in local dir  
-//var data = readFileSync('test.mp3');
-
-// Or if you want to access file from a url ..
-// const url = 'xyz.com/2019/01/T%C5%ABranga.mp3';
-// var data = await readDataFromUrl(url, 'audio/mp3');
 
 var result = await transcribeFile('test.mp3');
 

--- a/nodejs-asr/transcribe_file.js
+++ b/nodejs-asr/transcribe_file.js
@@ -1,0 +1,77 @@
+import { Buffer, Blob } from 'buffer';
+import axios from 'axios';
+import FormData from 'form-data';
+import fs from 'fs';
+import { auth_token } from './config.js'
+
+const transcribeFile = async (filename) => {
+
+    const formData = new FormData();
+    formData.enctype = "multipart/form-data";
+    //formData.append('audio_file', data, 'audio_file.mp3')        
+    formData.append('audio_file', fs.createReadStream(filename));
+
+    const url = 'https://asr.koreromaori.io/transcribe_file'
+    const config = {
+        headers: {
+            'content-type': 'multipart/form-data',
+            'Authorization': 'Token ' + auth_token
+        }
+    };
+
+    try {
+        var response = await axios.post(url, formData, config);
+        if (response.status==200 && response.data.success)
+        {
+            //console.log(response.data)
+            return response.data.transcription;
+        }
+        else {
+            msg = response.data.log;
+            //console.error(msg)
+            throw new Error('Problem transcribing file: ' + msg);
+        }
+    } catch (err) {
+        if (err.response && err.response.status==401) {
+            throw new Error("Authorization failure. Do you need to set the auth token (variable in transcribe.js)?");  
+        }
+        if (err.response && err.response.data && err.response.data.detail) {
+            throw new Error("Error transcribing file: (" + err.response.status + ') ' + err.response.data.detail);
+        }
+        else {
+            console.error(err);
+            throw err;
+        }
+          
+    }
+}
+
+// const readDataFromUrl = async (url, mimetype) => {
+//     try {
+//         var response = await axios.get(url,{
+//             responseType: 'arraybuffer',
+//             headers: {
+//                 'Content-Type': 'application/json',
+//                 'Accept': mimetype,
+//             }
+//         });
+//         if (response.status==200)
+//         {
+//             return response.data;
+//         }
+//     } catch (err) {
+//         throw new Error('Error reading file');
+//     }
+// }
+
+// using the test file in local dir  
+//var data = readFileSync('test.mp3');
+
+// Or if you want to access file from a url ..
+// const url = 'xyz.com/2019/01/T%C5%ABranga.mp3';
+// var data = await readDataFromUrl(url, 'audio/mp3');
+
+var result = await transcribeFile('test.mp3');
+
+// prints "tūranga tūranga"
+console.log(result)


### PR DESCRIPTION
@kmahelona  @cgsawtell, 

But thought I'd create this PR because for some reason I couldn't get this version that hits the /transcribe_file end point working. 

It's definitely just a nodejs thing not the end point because it works using the [docs](https://asr.koreromaori.io/docs#) end point

![image](https://user-images.githubusercontent.com/166867/164171541-fff4f1ca-1013-4cee-af8e-12ce5603848e.png)

Which claims that what it did corresponds to this curl 
```
curl -X 'POST' \
  'https://asr.koreromaori.io/transcribe_file' \
  -H 'accept: application/json' \
  -H 'Authorization:  Token xxxx-xxx' \
  -H 'Content-Type: multipart/form-data' \
  -F 'audio_file=@test.mp3;type=audio/mpeg'
```

But yeah, using the attached code (after I set the auth token) I get the following.. probably something stupid to do with multipart-mime types and blobs.

Would be good to have a version of both variations in this repo 

```
❯ node transcribe_file.js
file:///Users/utunga/papa/korero-maori-demos/nodejs-asr/transcribe_file.js:39
            throw new Error("Error transcribing file: (" + err.response.status + ') ' + err.response.data.detail);
                  ^

Error: Error transcribing file: (400) There was an error parsing the body
```
